### PR TITLE
Avoid coerced null string id for AI requests while creating ticket

### DIFF
--- a/src/aiUtils.js
+++ b/src/aiUtils.js
@@ -1,10 +1,23 @@
 export async function fetchAiResults(inputText, optionType) {
     try {
-        const response = await fetch(RT.Config.WebHomePath + '/Helpers/AISuggestion/ProcessAIRequest', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: new URLSearchParams({ rawText: inputText, callType: optionType, id: getTicketIdFromUrl(window.location.href) }).toString()
-        });
+        // Can be null on create ticket page
+        const ticketId = getTicketIdFromUrl(window.location.href);
+
+        const response = await fetch(
+            RT.Config.WebHomePath + "/Helpers/AISuggestion/ProcessAIRequest",
+            {
+                method: "POST",
+                headers: { "Content-Type": "application/x-www-form-urlencoded" },
+
+                // Prepare request parameters, including ticket id if available.
+                // Avoid encoding null here because this call would coerce null to "null".
+                body: new URLSearchParams({
+                    rawText: inputText,
+                    callType: optionType,
+                    ...(ticketId && { id: ticketId }),
+                }).toString(),
+            },
+        );
 
         if (!response.ok) {
             console.error('Error in fetchAiResults:', response.status, response.statusText);


### PR DESCRIPTION
A `null` id in JS for the current ticket id - on `Create.html` - becomes `"null"` (not falsy) in RT.  This logs errors server side and returns a spurious 404 code for `POST /Helpers/AISuggestion/ProcessAIRequest`.

Demonstration of this unwanted coercion in Chrome:
```js
>>> sp = new URLSearchParams({rawText: "Testing", callType: "autocomplete_text", id: null})
URLSearchParams {size: 3}
>>> sp.toString()
'rawText=Testing&callType=autocomplete_text&id=null'
>>> typeof sp.get("id")
'string'
```

This commit conditionally submits the ticket id only if present.