### PR TITLE
Display line-breaks returned by AI responses

### DIFF
--- a/src/modalUtils.js
+++ b/src/modalUtils.js
@@ -296,7 +296,7 @@ export async function createSuggestionModal(
                     const newDoneButton = modalManager.modalElement.querySelector('[name="done-button"]');
 
                     newDoneButton.addEventListener('click', () => {
-                        const aiResponse = suggestionText?.innerText?.replace(/^\s*|\s*$/g, '').trim();
+                        const aiResponse = suggestionText?.innerText?.replace(/^\s*|\s*$/g, '').trim().replace(/\n/g, '<br />');
 
                         if (!aiResponse) {
                             console.warn('No AI response to insert');

--- a/static/css/rt-extension-ai.css
+++ b/static/css/rt-extension-ai.css
@@ -1,3 +1,6 @@
 #aiModal {
     overflow-y: scroll;
 }
+#ai-result {
+    white-space: pre-wrap;
+}


### PR DESCRIPTION
- in the modal form, the div is filled by the AI response which is text with line breaks, hence it's needed to display it as pre-wrap.
- when user click the "done" button, the editor is filled with the AI response which is still text/plain with line breaks. Editor expects html tags for line breaks.